### PR TITLE
Add option to hide borrowing-selection

### DIFF
--- a/classes/configdata.php
+++ b/classes/configdata.php
@@ -45,7 +45,7 @@ class CConfigDataPIM
             'allow_negative_numbers' => 1,
             'decimal_step' => 0.1,
             'field_date_time_format' => 'date',
-            'hide_borrowing' => 0,
+            'disable_borrowing' => 0,
         ),
         'Plugininformationen' => array(
             'version' => '',

--- a/classes/configdata.php
+++ b/classes/configdata.php
@@ -45,6 +45,7 @@ class CConfigDataPIM
             'allow_negative_numbers' => 1,
             'decimal_step' => 0.1,
             'field_date_time_format' => 'date',
+            'hide_borrowing' => 0,
         ),
         'Plugininformationen' => array(
             'version' => '',

--- a/fields/fields.php
+++ b/fields/fields.php
@@ -122,6 +122,12 @@ $imfSystem = '';
 
 foreach ($items->mItemFields as $itemField) {
     $imfId = (int) $itemField->getValue('imf_id');
+    $imfNameIntern = $itemField->getValue('imf_name_intern');
+    $hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
+
+	if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+		break;
+	}
 
     // cut long text strings and provide tooltip
     $fieldDescription = $itemField->getValue('imf_description') === '' ? '&nbsp;' : $itemField->getValue('imf_description', 'database');

--- a/fields/fields.php
+++ b/fields/fields.php
@@ -123,9 +123,9 @@ $imfSystem = '';
 foreach ($items->mItemFields as $itemField) {
     $imfId = (int) $itemField->getValue('imf_id');
     $imfNameIntern = $itemField->getValue('imf_name_intern');
-    $hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
+    $disableBorrowing = $pPreferences->config['Optionen']['disable_borrowing'];
 
-	if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+	if ($disableBorrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
 		break;
 	}
 

--- a/import/import_column_config.php
+++ b/import/import_column_config.php
@@ -109,16 +109,26 @@ $arrayCsvColumns = array_filter($arrayCsvColumns, function ($value) {
 $categoryId = null;
 $arrayImportableFields = array();
 
+$pPreferences = new CConfigTablePIM();
+$pPreferences->read();
+
 $items = new CItems($gDb, $gCurrentOrgId);
 $row = array();
 foreach ($items->mItemFields as $columnKey => $columnValue) {
     $imfName = $columnValue->GetValue('imf_name');
     
+    $hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
+    $imfNameIntern = $columnValue->GetValue('imf_name_intern');
+
+    if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+		break;
+	}
+
     // If the field name starts with 'PIM_', it is a language key
     if (strpos($imfName, 'PIM_') !== false) {
-        $row = array($columnValue->GetValue('imf_name_intern') => $gL10n->get($imfName));
+        $row = array($imfNameIntern => $gL10n->get($imfName));
     } else {
-        $row = array($columnValue->GetValue('imf_name_intern') => $imfName);
+        $row = array($imfNameIntern => $imfName);
     }
     
     $arrayImportableFields[] = $row;

--- a/import/import_column_config.php
+++ b/import/import_column_config.php
@@ -117,10 +117,10 @@ $row = array();
 foreach ($items->mItemFields as $columnKey => $columnValue) {
     $imfName = $columnValue->GetValue('imf_name');
     
-    $hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
+    $disableBorrowing = $pPreferences->config['Optionen']['disable_borrowing'];
     $imfNameIntern = $columnValue->GetValue('imf_name_intern');
 
-    if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+    if ($disableBorrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
 		break;
 	}
 

--- a/inventory_manager.php
+++ b/inventory_manager.php
@@ -79,6 +79,7 @@ $sessionDefaults = array(
 // check if plugin need to be updated
 $pPreferences = new CConfigTablePIM();
 $pPreferences->checkForUpdate() ? $pPreferences->init() : $pPreferences->read();
+$hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'] ;
 
 // check if user is authorized for preferences panel
 if (isUserAuthorizedForPreferencesPIM()) {
@@ -469,6 +470,10 @@ foreach ($items->mItemFields as $itemField) {
     $imfNameIntern = $itemField->getValue('imf_name_intern');
     $columnHeader = convlanguagePIM($items->getProperty($imfNameIntern, 'imf_name'));
 
+    if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+        break;
+    }
+
     switch ($items->getProperty($imfNameIntern, 'imf_type')) {
         case 'CHECKBOX':
         case 'RADIO_BUTTON':
@@ -548,6 +553,10 @@ foreach ($items->items as $item) {
 
     foreach ($items->mItemFields as $itemField) {
         $imfNameIntern = $itemField->getValue('imf_name_intern');
+
+        if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+            break;
+        }
 
         if (($getFilterCategory !== '' && $imfNameIntern == 'CATEGORY' && $getFilterCategory != $items->getValue($imfNameIntern, 'database')) ||
                 ($getFilterKeeper !== 0 && $imfNameIntern == 'KEEPER' && $getFilterKeeper != $items->getValue($imfNameIntern))) {

--- a/inventory_manager.php
+++ b/inventory_manager.php
@@ -3,7 +3,7 @@
  ***********************************************************************************************
  * InventoryManager
  *
- * Version 1.1.6
+ * Version 1.1.7
  *
  * InventoryManager is an Admidio plugin for managing the inventory of an organisation.
  * 
@@ -79,7 +79,7 @@ $sessionDefaults = array(
 // check if plugin need to be updated
 $pPreferences = new CConfigTablePIM();
 $pPreferences->checkForUpdate() ? $pPreferences->init() : $pPreferences->read();
-$hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'] ;
+$disableBorrowing = $pPreferences->config['Optionen']['disable_borrowing'] ;
 
 // check if user is authorized for preferences panel
 if (isUserAuthorizedForPreferencesPIM()) {
@@ -470,7 +470,7 @@ foreach ($items->mItemFields as $itemField) {
     $imfNameIntern = $itemField->getValue('imf_name_intern');
     $columnHeader = convlanguagePIM($items->getProperty($imfNameIntern, 'imf_name'));
 
-    if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+    if ($disableBorrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
         break;
     }
 
@@ -554,7 +554,7 @@ foreach ($items->items as $item) {
     foreach ($items->mItemFields as $itemField) {
         $imfNameIntern = $itemField->getValue('imf_name_intern');
 
-        if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+        if ($disableBorrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
             break;
         }
 

--- a/inventory_manager_profile_addin.php
+++ b/inventory_manager_profile_addin.php
@@ -226,8 +226,14 @@ function insertReceiverView($page, $user, $itemsReceiver) : void
 {
 	global $gL10n, $gCurrentOrgId;
 
+	
 	$pPreferences = new CConfigTablePIM();
 	$pPreferences->read();
+
+	$hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
+	if ($hideborrowing == 1) { 
+		return;
+	}
 
 	$page->addHtml('
 			<div class="card admidio-field-group" id="inventory_manager_box_receiver">

--- a/inventory_manager_profile_addin.php
+++ b/inventory_manager_profile_addin.php
@@ -230,8 +230,8 @@ function insertReceiverView($page, $user, $itemsReceiver) : void
 	$pPreferences = new CConfigTablePIM();
 	$pPreferences->read();
 
-	$hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
-	if ($hideborrowing == 1) { 
+	$disableBorrowing = $pPreferences->config['Optionen']['disable_borrowing'];
+	if ($disableBorrowing == 1) { 
 		return;
 	}
 

--- a/items/items_delete.php
+++ b/items/items_delete.php
@@ -108,8 +108,8 @@ function displayItemDeleteForm($items, $user, $getItemId, $getItemFormer, $autho
 
 		$pPreferences = new CConfigTablePIM();
 		$pPreferences->read();
-		$hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
-		if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+		$disableBorrowing = $pPreferences->config['Optionen']['disable_borrowing'];
+		if ($disableBorrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
 			break;
 		}
 

--- a/items/items_delete.php
+++ b/items/items_delete.php
@@ -106,6 +106,13 @@ function displayItemDeleteForm($items, $user, $getItemId, $getItemFormer, $autho
 		$imfNameIntern = $itemField->getValue('imf_name_intern');
 		$content = $items->getValue($imfNameIntern, 'database');
 
+		$pPreferences = new CConfigTablePIM();
+		$pPreferences->read();
+		$hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
+		if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+			break;
+		}
+
 		if ($imfNameIntern === 'KEEPER' || $imfNameIntern == 'LAST_RECEIVER' && strlen($content) > 0) {
 			if (is_numeric($content)) {
 				$found = $user->readDataById($content);

--- a/items/items_edit_new.php
+++ b/items/items_edit_new.php
@@ -79,20 +79,20 @@ if ($getItemId != 0) {
 // Create HTML form
 $form = new HtmlForm('edit_item_form', SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_PLUGINS . PLUGIN_FOLDER_IM . '/items/items_save.php', array('item_id' => $getItemId)), $page);
 
-$hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
+$disableBorrowing = $pPreferences->config['Optionen']['disable_borrowing'];
 
 foreach ($items->mItemFields as $itemField) {
     $imfNameIntern = $itemField->getValue('imf_name_intern');
     if($imfNameIntern === 'IN_INVENTORY') {
         $pimInInventoryId = $items->getProperty($imfNameIntern, 'imf_id');
     }
-    if($imfNameIntern === 'LAST_RECEIVER' && $hideborrowing == 0) {
+    if($imfNameIntern === 'LAST_RECEIVER' && $disableBorrowing == 0) {
         $pimLastReceiverId = $items->getProperty($imfNameIntern, 'imf_id');
     }
-    if ($imfNameIntern === 'RECEIVED_ON' && $hideborrowing == 0) {
+    if ($imfNameIntern === 'RECEIVED_ON' && $disableBorrowing == 0) {
         $pimReceivedOnId = $items->getProperty($imfNameIntern, 'imf_id');
     }
-    if ($imfNameIntern === 'RECEIVED_BACK_ON' && $hideborrowing == 0) {
+    if ($imfNameIntern === 'RECEIVED_BACK_ON' && $disableBorrowing == 0) {
         $pimReceivedBackOnId = $items->getProperty($imfNameIntern, 'imf_id');
     }
 }
@@ -112,8 +112,7 @@ foreach ($items->mItemFields as $itemField) {
         $fieldProperty = HtmlForm::FIELD_DISABLED;
     }
 
-    $hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'] ;
-    if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+    if ($disableBorrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
         break;
     }
     

--- a/items/items_edit_new.php
+++ b/items/items_edit_new.php
@@ -110,7 +110,7 @@ foreach ($items->mItemFields as $itemField) {
         $fieldProperty = HtmlForm::FIELD_DISABLED;
     }
 
-    $hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'] ; //? null : '0'
+    $hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'] ;
     if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
         break;
     }

--- a/items/items_edit_new.php
+++ b/items/items_edit_new.php
@@ -109,6 +109,11 @@ foreach ($items->mItemFields as $itemField) {
     if (!$authorizedPreferences && !in_array($itemField->getValue('imf_name_intern'), $keeperEditFields)) {
         $fieldProperty = HtmlForm::FIELD_DISABLED;
     }
+
+    $hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'] ; //? null : '0'
+    if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+        break;
+    }
     
     if (isset($pimInInventoryId, $pimLastReceiverId, $pimReceivedOnId, $pimReceivedBackOnId) && $imfNameIntern === 'IN_INVENTORY') {
         $pPreferences->config['Optionen']['field_date_time_format'] === 'datetime' ? $datetime = 'true' : $datetime = 'false';

--- a/items/items_edit_new.php
+++ b/items/items_edit_new.php
@@ -79,18 +79,20 @@ if ($getItemId != 0) {
 // Create HTML form
 $form = new HtmlForm('edit_item_form', SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_PLUGINS . PLUGIN_FOLDER_IM . '/items/items_save.php', array('item_id' => $getItemId)), $page);
 
+$hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
+
 foreach ($items->mItemFields as $itemField) {
     $imfNameIntern = $itemField->getValue('imf_name_intern');
     if($imfNameIntern === 'IN_INVENTORY') {
         $pimInInventoryId = $items->getProperty($imfNameIntern, 'imf_id');
     }
-    if($imfNameIntern === 'LAST_RECEIVER') {
+    if($imfNameIntern === 'LAST_RECEIVER' && $hideborrowing == 0) {
         $pimLastReceiverId = $items->getProperty($imfNameIntern, 'imf_id');
     }
-    if ($imfNameIntern === 'RECEIVED_ON') {
+    if ($imfNameIntern === 'RECEIVED_ON' && $hideborrowing == 0) {
         $pimReceivedOnId = $items->getProperty($imfNameIntern, 'imf_id');
     }
-    if ($imfNameIntern === 'RECEIVED_BACK_ON') {
+    if ($imfNameIntern === 'RECEIVED_BACK_ON' && $hideborrowing == 0) {
         $pimReceivedBackOnId = $items->getProperty($imfNameIntern, 'imf_id');
     }
 }

--- a/languages/de-DE.xml
+++ b/languages/de-DE.xml
@@ -119,7 +119,7 @@
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER_DESC">Soll der aktuelle Benutzer beim Hinzufügen neuer Gegenstände standardmäßig als Verwalter voreingestellt werden, so ist der Haken zu setzen.</string>    
     <string name="PLG_INVENTORY_MANAGER_USING_CURRENT_VERSION">Sie benutzten eine aktuelle #VAR1#Version von InventoryManager!</string>
     <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING">Ausleih-Optionen verstecken</string>
-    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Verstecke die felder, die das ausleihen und zurückgeben abbilden.</string>
+    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Verstecke die Felder, die das Ausleihen und Zurückgeben abbilden.</string>
     <!-- Phrases only in Database -->
     <string name="PIM_CATEGORY">Kategorie</string>
     <string name="PIM_CATEGORY_DESCRIPTION">Die Kategorie des Gegenstandes</string>

--- a/languages/de-DE.xml
+++ b/languages/de-DE.xml
@@ -118,6 +118,8 @@
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER">aktueller Benutzer als Standardauswahl</string>
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER_DESC">Soll der aktuelle Benutzer beim Hinzufügen neuer Gegenstände standardmäßig als Verwalter voreingestellt werden, so ist der Haken zu setzen.</string>    
     <string name="PLG_INVENTORY_MANAGER_USING_CURRENT_VERSION">Sie benutzten eine aktuelle #VAR1#Version von InventoryManager!</string>
+    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING">Ausleih-Optionen verstecken</string>
+    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Verstecke die felder, die das ausleihen und zurückgeben abbilden.</string>
     <!-- Phrases only in Database -->
     <string name="PIM_CATEGORY">Kategorie</string>
     <string name="PIM_CATEGORY_DESCRIPTION">Die Kategorie des Gegenstandes</string>

--- a/languages/de-DE.xml
+++ b/languages/de-DE.xml
@@ -118,8 +118,8 @@
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER">aktueller Benutzer als Standardauswahl</string>
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER_DESC">Soll der aktuelle Benutzer beim Hinzufügen neuer Gegenstände standardmäßig als Verwalter voreingestellt werden, so ist der Haken zu setzen.</string>    
     <string name="PLG_INVENTORY_MANAGER_USING_CURRENT_VERSION">Sie benutzten eine aktuelle #VAR1#Version von InventoryManager!</string>
-    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING">Ausleih-Optionen verstecken</string>
-    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Verstecke die Felder, die das Ausleihen und Zurückgeben abbilden.</string>
+    <string name="PLG_INVENTORY_MANAGER_DISABLE_BORROWING">Ausleih-Optionen deaktivieren</string>
+    <string name="PLG_INVENTORY_MANAGER_DISABLE_BORROWING_DESC">Deaktiviere die Felder und deren Funktionen, die das Ausleihen und Zurückgeben von Gegenständen abbilden.</string>
     <!-- Phrases only in Database -->
     <string name="PIM_CATEGORY">Kategorie</string>
     <string name="PIM_CATEGORY_DESCRIPTION">Die Kategorie des Gegenstandes</string>

--- a/languages/de.xml
+++ b/languages/de.xml
@@ -118,8 +118,8 @@
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER">aktueller Benutzer als Standardauswahl</string>
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER_DESC">Soll der aktuelle Benutzer beim Hinzufügen neuer Gegenstände standardmäßig als Verwalter voreingestellt werden, so ist der Haken zu setzen.</string>    
     <string name="PLG_INVENTORY_MANAGER_USING_CURRENT_VERSION">Du benutzt eine aktuelle #VAR1#Version von InventoryManager!</string>
-    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING">Ausleih-Optionen verstecken</string>
-    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Verstecke die Felder, die das Ausleihen und Zurückgeben abbilden.</string>
+    <string name="PLG_INVENTORY_MANAGER_DISABLE_BORROWING">Ausleih-Optionen deaktivieren</string>
+    <string name="PLG_INVENTORY_MANAGER_DISABLE_BORROWING_DESC">Deaktiviere die Felder und deren Funktionen, die das Ausleihen und Zurückgeben von Gegenständen abbilden.</string>
     <!-- Phrases only in Database -->
     <string name="PIM_CATEGORY">Kategorie</string>
     <string name="PIM_CATEGORY_DESCRIPTION">Die Kategorie des Gegenstandes</string>

--- a/languages/de.xml
+++ b/languages/de.xml
@@ -118,6 +118,8 @@
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER">aktueller Benutzer als Standardauswahl</string>
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER_DESC">Soll der aktuelle Benutzer beim Hinzufügen neuer Gegenstände standardmäßig als Verwalter voreingestellt werden, so ist der Haken zu setzen.</string>    
     <string name="PLG_INVENTORY_MANAGER_USING_CURRENT_VERSION">Du benutzt eine aktuelle #VAR1#Version von InventoryManager!</string>
+    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING">Ausleih-Optionen verstecken</string>
+    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Verstecke die felder, die das ausleihen und zurückgeben abbilden.</string>
     <!-- Phrases only in Database -->
     <string name="PIM_CATEGORY">Kategorie</string>
     <string name="PIM_CATEGORY_DESCRIPTION">Die Kategorie des Gegenstandes</string>

--- a/languages/de.xml
+++ b/languages/de.xml
@@ -119,7 +119,7 @@
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER_DESC">Soll der aktuelle Benutzer beim Hinzufügen neuer Gegenstände standardmäßig als Verwalter voreingestellt werden, so ist der Haken zu setzen.</string>    
     <string name="PLG_INVENTORY_MANAGER_USING_CURRENT_VERSION">Du benutzt eine aktuelle #VAR1#Version von InventoryManager!</string>
     <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING">Ausleih-Optionen verstecken</string>
-    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Verstecke die felder, die das ausleihen und zurückgeben abbilden.</string>
+    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Verstecke die Felder, die das Ausleihen und Zurückgeben abbilden.</string>
     <!-- Phrases only in Database -->
     <string name="PIM_CATEGORY">Kategorie</string>
     <string name="PIM_CATEGORY_DESCRIPTION">Die Kategorie des Gegenstandes</string>

--- a/languages/en.xml
+++ b/languages/en.xml
@@ -118,6 +118,8 @@
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER">Current user as default selection</string>
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER_DESC">If the current user is to be preset as the keeper when adding new items, the checkbox must be checked.</string>
     <string name="PLG_INVENTORY_MANAGER_USING_CURRENT_VERSION">You are using the current #VAR1# version of InventoryManager!</string>
+    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING">Hide borrowing options</string>
+    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Hide the selections for borrowing and returning devices to people</string>
     <!-- Phrases only in Database -->
     <string name="PIM_CATEGORY">Category</string>
     <string name="PIM_CATEGORY_DESCRIPTION">Category of the item</string>

--- a/languages/en.xml
+++ b/languages/en.xml
@@ -119,7 +119,7 @@
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER_DESC">If the current user is to be preset as the keeper when adding new items, the checkbox must be checked.</string>
     <string name="PLG_INVENTORY_MANAGER_USING_CURRENT_VERSION">You are using the current #VAR1# version of InventoryManager!</string>
     <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING">Hide borrowing options</string>
-    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Hide the selections for borrowing and returning devices to people</string>
+    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Hide the selections for borrowing and returning devices to people.</string>
     <!-- Phrases only in Database -->
     <string name="PIM_CATEGORY">Category</string>
     <string name="PIM_CATEGORY_DESCRIPTION">Category of the item</string>

--- a/languages/en.xml
+++ b/languages/en.xml
@@ -118,8 +118,8 @@
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER">Current user as default selection</string>
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER_DESC">If the current user is to be preset as the keeper when adding new items, the checkbox must be checked.</string>
     <string name="PLG_INVENTORY_MANAGER_USING_CURRENT_VERSION">You are using the current #VAR1# version of InventoryManager!</string>
-    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING">Hide borrowing options</string>
-    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Hide the selections for borrowing and returning devices to people.</string>
+    <string name="PLG_INVENTORY_MANAGER_DISABLE_BORROWING">Deactivate borrowing options</string>
+    <string name="PLG_INVENTORY_MANAGER_DISABLE_BORROWING_DESC">Deactivate the fields and their functions that represent the borrowing and returning of items.</string>
     <!-- Phrases only in Database -->
     <string name="PIM_CATEGORY">Category</string>
     <string name="PIM_CATEGORY_DESCRIPTION">Category of the item</string>

--- a/languages/fr.xml
+++ b/languages/fr.xml
@@ -119,7 +119,7 @@
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER_DESC">Si l'utilisateur actuel doit être défini par défaut comme gestionnaire lors de l'ajout de nouveaux objets, cochez cette case.</string>    
     <string name="PLG_INVENTORY_MANAGER_USING_CURRENT_VERSION">Vous utilisez une #VAR1#version actuelle  d'InventoryManager!</string>
     <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING">Cacher les options de location</string>
-    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Masquer les sélections pour l'emprunt et la restitution d'appareils aux personnes</string>
+    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Masquer les sélections pour l'emprunt et la restitution d'appareils aux personnes.</string>
     <!-- Phrases only in Database -->
     <string name="PIM_CATEGORY">Catégorie</string>
     <string name="PIM_CATEGORY_DESCRIPTION">La catégorie de l'objet</string>

--- a/languages/fr.xml
+++ b/languages/fr.xml
@@ -118,8 +118,8 @@
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER">Utilisateur actuel comme sélection par défaut</string>
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER_DESC">Si l'utilisateur actuel doit être défini par défaut comme gestionnaire lors de l'ajout de nouveaux objets, cochez cette case.</string>    
     <string name="PLG_INVENTORY_MANAGER_USING_CURRENT_VERSION">Vous utilisez une #VAR1#version actuelle  d'InventoryManager!</string>
-    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING">Cacher les options de location</string>
-    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Masquer les sélections pour l'emprunt et la restitution d'appareils aux personnes.</string>
+    <string name="PLG_INVENTORY_MANAGER_DISABLE_BORROWING">Désactiver les options d'emprunt</string>
+    <string name="PLG_INVENTORY_MANAGER_DISABLE_BORROWING_DESC">Désactivez les champs et leurs fonctions qui représentent l'emprunt et le retour d'objets.</string>
     <!-- Phrases only in Database -->
     <string name="PIM_CATEGORY">Catégorie</string>
     <string name="PIM_CATEGORY_DESCRIPTION">La catégorie de l'objet</string>

--- a/languages/fr.xml
+++ b/languages/fr.xml
@@ -118,6 +118,8 @@
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER">Utilisateur actuel comme sélection par défaut</string>
     <string name="PLG_INVENTORY_MANAGER_USE_CURRENT_USER_DESC">Si l'utilisateur actuel doit être défini par défaut comme gestionnaire lors de l'ajout de nouveaux objets, cochez cette case.</string>    
     <string name="PLG_INVENTORY_MANAGER_USING_CURRENT_VERSION">Vous utilisez une #VAR1#version actuelle  d'InventoryManager!</string>
+    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING">Cacher les options de location</string>
+    <string name="PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC">Masquer les sélections pour l'emprunt et la restitution d'appareils aux personnes</string>
     <!-- Phrases only in Database -->
     <string name="PIM_CATEGORY">Catégorie</string>
     <string name="PIM_CATEGORY_DESCRIPTION">La catégorie de l'objet</string>

--- a/preferences/preferences.php
+++ b/preferences/preferences.php
@@ -98,8 +98,8 @@ $valueList = array();
 foreach ($items->mItemFields as $itemField) {
 
     $imfNameIntern = $itemField->getValue('imf_name_intern');
-    $hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
-    if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+    $disableBorrowing = $pPreferences->config['Optionen']['disable_borrowing'];
+    if ($disableBorrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
 		break;
 	}
     
@@ -114,11 +114,11 @@ $formGeneralSettings->addCheckbox('current_user_default_keeper', $gL10n->get('PL
 $formGeneralSettings->addCheckbox('allow_negative_numbers', $gL10n->get('PLG_INVENTORY_MANAGER_ALLOW_NEGATIVE_NUMBERS'), $pPreferences->config['Optionen']['allow_negative_numbers'], array('helpTextIdInline' => 'PLG_INVENTORY_MANAGER_ALLOW_NEGATIVE_NUMBERS_DESC'));
 $formGeneralSettings->addInput('decimal_step', $gL10n->get('PLG_INVENTORY_MANAGER_DECIMAL_STEP'), $pPreferences->config['Optionen']['decimal_step'], array('type' => 'number','minNumber' => 0, 'step' => '0.0000001', 'helpTextIdLabel' => 'PLG_INVENTORY_MANAGER_DECIMAL_STEP_DESC', 'property' => HtmlForm::FIELD_REQUIRED));
 
-if ($hideborrowing == 0) { 
+if ($disableBorrowing == 0) { 
 		$formGeneralSettings->addSelectBox('field_date_time_format', $gL10n->get('PLG_INVENTORY_MANAGER_DATETIME_FORMAT'), array($gL10n->get('SYS_DATE'), $gL10n->get('SYS_DATE') .' & ' .$gL10n->get('SYS_TIME')), array('defaultValue' => (($pPreferences->config['Optionen']['field_date_time_format'] === 'datetime') ? 1 : 0), 'showContextDependentFirstEntry' => false));
 }
 
-$formGeneralSettings->addCheckbox('hide_borrowing', $gL10n->get('PLG_INVENTORY_MANAGER_HIDE_BORROWING'), $pPreferences->config['Optionen']['hide_borrowing'], array('helpTextIdInline' => 'PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC'));
+$formGeneralSettings->addCheckbox('disable_borrowing', $gL10n->get('PLG_INVENTORY_MANAGER_DISABLE_BORROWING'), $pPreferences->config['Optionen']['disable_borrowing'], array('helpTextIdInline' => 'PLG_INVENTORY_MANAGER_DISABLE_BORROWING_DESC'));
 
 $formGeneralSettings->addSubmitButton('btn_save_general_preferences', $gL10n->get('SYS_SAVE'), array('icon' => 'fa-check', 'class' => ' offset-sm-3'));
 addPreferencePanel($page, 'field_settings', $gL10n->get('SYS_COMMON'), 'fas fa-cog fa-fw', $formGeneralSettings->show());
@@ -135,8 +135,8 @@ $valueList = array();
 foreach ($items->mItemFields as $itemField) {
 
     $imfNameIntern = $itemField->getValue('imf_name_intern');
-    $hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
-    if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+    $disableBorrowing = $pPreferences->config['Optionen']['disable_borrowing'];
+    if ($disableBorrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
 		break;
 	}
 

--- a/preferences/preferences.php
+++ b/preferences/preferences.php
@@ -96,7 +96,14 @@ $page->addHtml('
 $items = new CItems($gDb, $gCurrentOrgId);
 $valueList = array();
 foreach ($items->mItemFields as $itemField) {
-    $valueList[$itemField->getValue('imf_name_intern')] = $itemField->getValue('imf_name');
+
+    $imfNameIntern = $itemField->getValue('imf_name_intern');
+    $hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
+    if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+		break;
+	}
+    
+    $valueList[$imfNameIntern] = $itemField->getValue('imf_name');
 }
 
 // PANEL: GENERAL PREFERENCES
@@ -123,6 +130,13 @@ addPreferencePanel($page, 'itemfields', $gL10n->get('PLG_INVENTORY_MANAGER_ITEMF
 $helpTextIdLabelLink = '<a href="https://github.com/MightyMCoder/InventoryManager/wiki/Profile-View-AddIn" target="_blank">GitHub Wiki</a>';
 $valueList = array();
 foreach ($items->mItemFields as $itemField) {
+
+    $imfNameIntern = $itemField->getValue('imf_name_intern');
+    $hideborrowing = $pPreferences->config['Optionen']['hide_borrowing'];
+    if ($hideborrowing == 1 && ($imfNameIntern === 'LAST_RECEIVER' || $imfNameIntern === 'RECEIVED_ON' || $imfNameIntern === 'RECEIVED_BACK_ON')) { 
+		break;
+	}
+
     if ($itemField->getValue('imf_name_intern') == 'ITEMNAME') {
         continue;
     }

--- a/preferences/preferences.php
+++ b/preferences/preferences.php
@@ -107,6 +107,9 @@ $formGeneralSettings->addCheckbox('current_user_default_keeper', $gL10n->get('PL
 $formGeneralSettings->addCheckbox('allow_negative_numbers', $gL10n->get('PLG_INVENTORY_MANAGER_ALLOW_NEGATIVE_NUMBERS'), $pPreferences->config['Optionen']['allow_negative_numbers'], array('helpTextIdInline' => 'PLG_INVENTORY_MANAGER_ALLOW_NEGATIVE_NUMBERS_DESC'));
 $formGeneralSettings->addInput('decimal_step', $gL10n->get('PLG_INVENTORY_MANAGER_DECIMAL_STEP'), $pPreferences->config['Optionen']['decimal_step'], array('type' => 'number','minNumber' => 0, 'step' => '0.0000001', 'helpTextIdLabel' => 'PLG_INVENTORY_MANAGER_DECIMAL_STEP_DESC', 'property' => HtmlForm::FIELD_REQUIRED));
 $formGeneralSettings->addSelectBox('field_date_time_format', $gL10n->get('PLG_INVENTORY_MANAGER_DATETIME_FORMAT'), array($gL10n->get('SYS_DATE'), $gL10n->get('SYS_DATE') .' & ' .$gL10n->get('SYS_TIME')), array('defaultValue' => (($pPreferences->config['Optionen']['field_date_time_format'] === 'datetime') ? 1 : 0), 'showContextDependentFirstEntry' => false));
+
+$formGeneralSettings->addCheckbox('hide_borrowing', $gL10n->get('PLG_INVENTORY_MANAGER_HIDE_BORROWING'), $pPreferences->config['Optionen']['hide_borrowing'], array('helpTextIdInline' => 'PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC'));
+
 $formGeneralSettings->addSubmitButton('btn_save_general_preferences', $gL10n->get('SYS_SAVE'), array('icon' => 'fa-check', 'class' => ' offset-sm-3'));
 addPreferencePanel($page, 'field_settings', $gL10n->get('SYS_COMMON'), 'fas fa-cog fa-fw', $formGeneralSettings->show());
 

--- a/preferences/preferences.php
+++ b/preferences/preferences.php
@@ -113,7 +113,10 @@ $formGeneralSettings->addSelectBox('allowed_keeper_edit_fields', $gL10n->get('PL
 $formGeneralSettings->addCheckbox('current_user_default_keeper', $gL10n->get('PLG_INVENTORY_MANAGER_USE_CURRENT_USER'), $pPreferences->config['Optionen']['current_user_default_keeper'], array('helpTextIdInline' => 'PLG_INVENTORY_MANAGER_USE_CURRENT_USER_DESC'));
 $formGeneralSettings->addCheckbox('allow_negative_numbers', $gL10n->get('PLG_INVENTORY_MANAGER_ALLOW_NEGATIVE_NUMBERS'), $pPreferences->config['Optionen']['allow_negative_numbers'], array('helpTextIdInline' => 'PLG_INVENTORY_MANAGER_ALLOW_NEGATIVE_NUMBERS_DESC'));
 $formGeneralSettings->addInput('decimal_step', $gL10n->get('PLG_INVENTORY_MANAGER_DECIMAL_STEP'), $pPreferences->config['Optionen']['decimal_step'], array('type' => 'number','minNumber' => 0, 'step' => '0.0000001', 'helpTextIdLabel' => 'PLG_INVENTORY_MANAGER_DECIMAL_STEP_DESC', 'property' => HtmlForm::FIELD_REQUIRED));
-$formGeneralSettings->addSelectBox('field_date_time_format', $gL10n->get('PLG_INVENTORY_MANAGER_DATETIME_FORMAT'), array($gL10n->get('SYS_DATE'), $gL10n->get('SYS_DATE') .' & ' .$gL10n->get('SYS_TIME')), array('defaultValue' => (($pPreferences->config['Optionen']['field_date_time_format'] === 'datetime') ? 1 : 0), 'showContextDependentFirstEntry' => false));
+
+if ($hideborrowing == 0) { 
+		$formGeneralSettings->addSelectBox('field_date_time_format', $gL10n->get('PLG_INVENTORY_MANAGER_DATETIME_FORMAT'), array($gL10n->get('SYS_DATE'), $gL10n->get('SYS_DATE') .' & ' .$gL10n->get('SYS_TIME')), array('defaultValue' => (($pPreferences->config['Optionen']['field_date_time_format'] === 'datetime') ? 1 : 0), 'showContextDependentFirstEntry' => false));
+}
 
 $formGeneralSettings->addCheckbox('hide_borrowing', $gL10n->get('PLG_INVENTORY_MANAGER_HIDE_BORROWING'), $pPreferences->config['Optionen']['hide_borrowing'], array('helpTextIdInline' => 'PLG_INVENTORY_MANAGER_HIDE_BORROWING_DESC'));
 

--- a/preferences/preferences_function.php
+++ b/preferences/preferences_function.php
@@ -99,7 +99,7 @@ function handleFormSubmission($form, $preferences) : void
 			$preferences->config['Optionen']['allow_negative_numbers'] = isset($_POST['allow_negative_numbers']) ? 1 : 0;
 			$preferences->config['Optionen']['decimal_step'] = sprintf('%.7f', (float)$_POST['decimal_step']);
 			$preferences->config['Optionen']['field_date_time_format'] = ($_POST['field_date_time_format'] == "0") ? 'date': 'datetime';
-			$preferences->config['Optionen']['hide_borrowing'] = isset($_POST['hide_borrowing']) ? 1 : 0;
+			$preferences->config['Optionen']['disable_borrowing'] = isset($_POST['disable_borrowing']) ? 1 : 0;
 			break;
 
 		default:

--- a/preferences/preferences_function.php
+++ b/preferences/preferences_function.php
@@ -99,6 +99,7 @@ function handleFormSubmission($form, $preferences) : void
 			$preferences->config['Optionen']['allow_negative_numbers'] = isset($_POST['allow_negative_numbers']) ? 1 : 0;
 			$preferences->config['Optionen']['decimal_step'] = sprintf('%.7f', (float)$_POST['decimal_step']);
 			$preferences->config['Optionen']['field_date_time_format'] = ($_POST['field_date_time_format'] == "0") ? 'date': 'datetime';
+			$preferences->config['Optionen']['hide_borrowing'] = isset($_POST['hide_borrowing']) ? 1 : 0;
 			break;
 
 		default:

--- a/version.php
+++ b/version.php
@@ -11,9 +11,9 @@
  */
 
 class CPluginInfoPIM {
-    protected const PLUGIN_VERSION = '1.1.6';
+    protected const PLUGIN_VERSION = '1.1.7';
     protected const PLUGIN_VERSION_BETA = 'n/a';
-    protected const PLUGIN_STAND = '23.03.2025';
+    protected const PLUGIN_STAND = '04.05.2025';
 
     /**
      * Current version of plugin InventoryManager


### PR DESCRIPTION
As I understand the option to log borrowing and returning stuff is core to this plugin, but not everyone needs it.

This PR adds a checkbox that removes that part of the plugin from the UI.

The changes I made are somewhat breaking, since I added a `hide_borrowing`-entry in configdata.php which means the plugin has to be reinstalled for it to work.